### PR TITLE
add a dry run flag to RM_Call execution

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -50,4 +50,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/eventloop \
 --single unit/moduleapi/timer \
 --single unit/moduleapi/publish \
+--single unit/moduleapi/dryrun \
 "${@}"

--- a/src/module.c
+++ b/src/module.c
@@ -357,6 +357,7 @@ typedef struct RedisModuleServerInfoData {
 #define REDISMODULE_ARGV_NO_WRITES (1<<7)
 #define REDISMODULE_ARGV_CALL_REPLIES_AS_ERRORS (1<<8)
 #define REDISMODULE_ARGV_RESPECT_DENY_OOM (1<<9)
+#define REDISMODULE_ARGV_DRY_RUN (1<<10)
 
 /* Determine whether Redis should signalModifiedKey implicitly.
  * In case 'ctx' has no 'module' member (and therefore no module->options),
@@ -5695,6 +5696,8 @@ robj **moduleCreateArgvFromUserFormat(const char *cmdname, const char *fmt, int 
             if (flags) (*flags) |= REDISMODULE_ARGV_RESPECT_DENY_OOM;
         } else if (*p == 'E') {
             if (flags) (*flags) |= REDISMODULE_ARGV_CALL_REPLIES_AS_ERRORS;
+        } else if (*p == 'D') {
+            if (flags) (*flags) |= (REDISMODULE_ARGV_DRY_RUN | REDISMODULE_ARGV_CALL_REPLIES_AS_ERRORS);
         } else {
             goto fmterr;
         }
@@ -5746,6 +5749,10 @@ fmterr:
  *              invoking the command, the error is returned using errno mechanism.
  *              This flag allows to get the error also as an error CallReply with
  *              relevant error message.
+ *     * 'D' -- A "Dry Run" mode.  Return before executing the underlying call().
+ *              if everything succeeded, it will return with a NULL, otherwise it will
+ *              return with a CallReply object denoting the error, as if it was called with
+ *              the 'E' code.
  * * **...**: The actual arguments to the Redis command.
  *
  * On success a RedisModuleCallReply object is returned, otherwise
@@ -5995,6 +6002,10 @@ RedisModuleCallReply *RM_Call(RedisModuleCtx *ctx, const char *cmdname, const ch
             }
             goto cleanup;
         }
+    }
+
+    if (flags & REDISMODULE_ARGV_DRY_RUN) {
+        goto cleanup;
     }
 
     /* We need to use a global replication_allowed flag in order to prevent

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -58,7 +58,8 @@ TEST_MODULES = \
     eventloop.so \
     moduleconfigs.so \
     moduleconfigstwo.so \
-    publish.so
+    publish.so \
+    dryrun.so
 
 .PHONY: all
 

--- a/tests/modules/dryrun.c
+++ b/tests/modules/dryrun.c
@@ -1,0 +1,43 @@
+
+#include "redismodule.h"
+#include <errno.h>
+#include <assert.h>
+#include <string.h>
+#include <strings.h>
+
+/* A wrap for SET command with ACL check on the key. */
+int dryrun(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc < 3) {
+        return RedisModule_WrongArity(ctx);
+    }
+
+    size_t cmd_len;
+    const char *cmd = RedisModule_StringPtrLen(argv[1], &cmd_len);
+
+    RedisModuleCallReply *rep = RedisModule_Call(ctx, cmd, "CMDv", argv + 2, argc - 2);
+
+    if (rep) {
+        RedisModule_ReplyWithCallReply(ctx, rep);
+    } else {
+        RedisModule_ReplyWithSimpleString(ctx, "OK");
+    }
+
+    if (rep) {
+        RedisModule_FreeCallReply(rep);
+    }
+
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx,"dryrun",1,REDISMODULE_APIVER_1)== REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    if (RedisModule_CreateCommand(ctx,"dryrun", dryrun,"",0,0,0) == REDISMODULE_ERR)
+        return REDISMODULE_ERR;
+
+    return REDISMODULE_OK;
+}

--- a/tests/unit/moduleapi/dryrun.tcl
+++ b/tests/unit/moduleapi/dryrun.tcl
@@ -30,7 +30,7 @@ start_server {tags {"modules"}} {
         r acl setuser default +get -set +dryrun resetkeys ~x
 
         catch {r dryrun set x 5} e
-        assert_match {*NOPERM*} $e
+        assert_match {*ERR acl verification failed, can't run this command or subcommand*} $e
         assert_equal [r get x] $val
     }
 }

--- a/tests/unit/moduleapi/dryrun.tcl
+++ b/tests/unit/moduleapi/dryrun.tcl
@@ -1,0 +1,36 @@
+set testmodule [file normalize tests/modules/dryrun.so]
+
+start_server {tags {"modules"}} {
+    r module load $testmodule
+
+    test {test Dry Run - OK OOM} {
+        set val [r get x]
+        assert_equal [r dryrun set x 5] OK
+        assert_equal [r get x] $val
+    }
+
+    test {test Dry Run - OK ACL} {
+        set val [r get x]
+        assert_equal [r dryrun set x 5] OK
+        assert_equal [r get x] $val
+    }
+
+    test {test Dry Run - Fail OOM} {
+        set val [r get x]
+        r config set maxmemory 1
+        catch {r dryrun set x 5} e
+        assert_match {*OOM*} $e
+        r config set maxmemory 100000000000
+        assert_equal [r get x] $val
+    }
+
+    test {test Dry Run - Fail ACL} {
+        set val [r get x]
+        # deny all permissions besides the dryrun command
+        r acl setuser default +get -set +dryrun resetkeys ~x
+
+        catch {r dryrun set x 5} e
+        assert_match {*NOPERM*} $e
+        assert_equal [r get x] $val
+    }
+}


### PR DESCRIPTION
this creates a new mode that runs whatever verifications the user requests from the RM_Call, but returns before the actual execution of the command.

It automatically enables returning error messages as CallReply objects to distinguish success (NULL) from failure (CallReply returned).