### PR TITLE
enable RM_Call to call scripts with OOM checking disabled.

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -5700,7 +5700,7 @@ robj **moduleCreateArgvFromUserFormat(const char *cmdname, const char *fmt, int 
         } else if (*p == 'O') {
             if (flags) (*flags) |= REDISMODULE_ARGV_ALLOW_OOM_IN_SCRIPTS;
         } else {
-                goto fmterr;
+            goto fmterr;
         }
         p++;
     }

--- a/src/server.h
+++ b/src/server.h
@@ -368,6 +368,8 @@ extern int configOOMScoreAdjValuesDefaults[CONFIG_OOM_COUNT];
                                           RDB without replication buffer. */
 #define CLIENT_NO_EVICT (1ULL<<43) /* This client is protected against client
                                       memory eviction. */
+#define CLIENT_ALLOW_OOM (1ULL<<44) /* Client used by RM_Call is allowed to fully execute
+                                       scripts even when in OOM */
 
 /* Client block type (btype field in client structure)
  * if CLIENT_BLOCKED flag is set. */

--- a/tests/unit/moduleapi/misc.tcl
+++ b/tests/unit/moduleapi/misc.tcl
@@ -219,6 +219,11 @@ start_server {tags {"modules"}} {
             } 1 x
         }
 
+        r test.rm_call_flags O eval {
+            redis.call('set','x',1)
+            return 1
+        } 1 x
+
         r test.rm_call eval {
             redis.call('get','x')
             return 4


### PR DESCRIPTION
previously, while RM_Call ignores OOM for regular commands, it
would execute scripts normally which could cause the script
(depending on how they are configured) to OOM on their own in the
middle of execution.

This allows the caller of RM_Call to specify a flag that will
allow the module to ensure that scripts it executes will run even
if redis is > maxmemory limit.